### PR TITLE
Fix: 초기 접속시 토스트 방지

### DIFF
--- a/src/components/Kakaomap.tsx
+++ b/src/components/Kakaomap.tsx
@@ -14,6 +14,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useErrorToastStore } from '@/store/errorToastStore';
 import { useGetTypeStore } from '@/store/getTypeStore';
 import { useSystemStore } from '@/store/systemErrorStore';
+import { useIsInSeoulStroe } from '@/store/isInSeoulStore';
 
 export default function Kakaomap({
 	controls,
@@ -41,7 +42,7 @@ export default function Kakaomap({
 	const [geocoder, setGeocoder] = useState<kakao.maps.services.Geocoder | null>(
 		null,
 	);
-	const [isNotSeoul, setIsNotSeoul] = useState(false);
+	const { isInSeoul, setIsInSeoul } = useIsInSeoulStroe();
 
 	const handleDragEnd = (map: kakao.maps.Map) => {
 		const latlng = map.getCenter();
@@ -74,11 +75,11 @@ export default function Kakaomap({
 		geocoder?.coord2RegionCode(center.lng, center.lat, (result, status) => {
 			if (status === kakao.maps.services.Status.OK) {
 				if (result[0].address_name.slice(0, 5) !== '서울특별시') {
-					setIsNotSeoul(true);
+					setIsInSeoul(false);
 					setErrorContent('SEOUL');
 					setIsToastError(true);
 				} else {
-					setIsNotSeoul(false);
+					setIsInSeoul(true);
 				}
 			}
 		});
@@ -103,7 +104,7 @@ export default function Kakaomap({
 			isADDRESSCollectionsLoading || isLATLNGCollectionsLoading;
 
 		if (isSearchDataEmpty || isLatlngDataEmpty) {
-			if (!isNotSeoul && !isDataLoading) {
+			if (isInSeoul && !isDataLoading) {
 				setErrorContent('DATA');
 				setIsToastError(true);
 			}

--- a/src/components/Kakaomap.tsx
+++ b/src/components/Kakaomap.tsx
@@ -9,7 +9,7 @@ import useSearchCollections from '@/hooks/useSearchCollections';
 import { useSetIsSidebarOpen } from '@/store/sidebarStateStore';
 import { useSelectedFilters } from '@/store/collectionFilterStore';
 import { useMapRef } from '@/store/useMapRefStore';
-import { useMapDataStore } from '@/store/useMapDataStore';
+import { DEFAULT_LOCATION, useMapDataStore } from '@/store/useMapDataStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useErrorToastStore } from '@/store/errorToastStore';
 import { useGetTypeStore } from '@/store/getTypeStore';
@@ -104,7 +104,7 @@ export default function Kakaomap({
 			isADDRESSCollectionsLoading || isLATLNGCollectionsLoading;
 
 		if (isSearchDataEmpty || isLatlngDataEmpty) {
-			if (isInSeoul && !isDataLoading) {
+			if (isInSeoul && !isDataLoading && center !== DEFAULT_LOCATION) {
 				setErrorContent('DATA');
 				setIsToastError(true);
 			}

--- a/src/components/Kakaomap.tsx
+++ b/src/components/Kakaomap.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Map, MapMarker as Marker } from 'react-kakao-maps-sdk';
 import MapMarker from './MapMarker';
 import useKakaoLoader from '@/utils/util';
@@ -110,6 +110,21 @@ export default function Kakaomap({
 		}
 	}, [collectionsLATLNG, collectionsADDRESS]);
 	/* eslint-enable react-hooks/exhaustive-deps */
+
+	const filteredLATLNGCollections = useMemo(() => {
+		if (!collectionsLATLNG || !collectionsLATLNG.data) return [];
+		return collectionsLATLNG.data.filter((collection) =>
+			selectedFilters.includes(collection.tag),
+		);
+	}, [collectionsLATLNG, selectedFilters]);
+
+	const filteredADDRESSCollections = useMemo(() => {
+		if (!collectionsADDRESS || !collectionsADDRESS.data) return [];
+		return collectionsADDRESS.data.filter((collection) =>
+			selectedFilters.includes(collection.tag),
+		);
+	}, [collectionsADDRESS, selectedFilters]);
+
 	return (
 		<Map
 			center={center}
@@ -129,30 +144,20 @@ export default function Kakaomap({
 			}}
 			onClick={handleClickMap}
 		>
-			{collectionsLATLNG &&
-				collectionsLATLNG?.data?.length > 0 &&
-				getType === 'LATLNG' &&
-				collectionsLATLNG.data
-					.filter((collection) => selectedFilters.includes(collection.tag))
-					.map((collection) => (
-						<MapMarker
-							key={collection.id}
-							collection={collection}
-							controls={controls}
-						/>
-					))}
-			{collectionsADDRESS &&
-				collectionsADDRESS?.data?.length > 0 &&
-				getType === 'SEARCH' &&
-				collectionsADDRESS.data
-					.filter((collection) => selectedFilters.includes(collection.tag))
-					.map((collection) => (
-						<MapMarker
-							key={collection.id}
-							collection={collection}
-							controls={controls}
-						/>
-					))}
+			{filteredLATLNGCollections.map((collection) => (
+				<MapMarker
+					key={collection.id}
+					collection={collection}
+					controls={controls}
+				/>
+			))}
+			{filteredADDRESSCollections.map((collection) => (
+				<MapMarker
+					key={collection.id}
+					collection={collection}
+					controls={controls}
+				/>
+			))}
 			{location && <Marker position={location} />}
 		</Map>
 	);

--- a/src/components/MapController.tsx
+++ b/src/components/MapController.tsx
@@ -16,7 +16,7 @@ const MapController = () => {
 		if (!location) return;
 		setCenter(location);
 	};
-
+	/* eslint-disable react-hooks/exhaustive-deps */
 	useEffect(() => {
 		navigator.geolocation.getCurrentPosition((position) => {
 			setLocation({
@@ -24,15 +24,15 @@ const MapController = () => {
 				lng: position.coords.longitude,
 			});
 		});
-	}, [setLocation]);
+	}, []);
 
 	useEffect(() => {
 		if (location) {
 			setCenter(location);
 			setSearchCenter(location);
 		}
-	}, [location, setCenter, setSearchCenter]);
-
+	}, [location]);
+	/* eslint-enable react-hooks/exhaustive-deps */
 	return (
 		<div className="fixed left-0 top-0 w-full px-6 pt-12 xl:static xl:pt-6">
 			<div className="flex flex-col gap-S-14">

--- a/src/components/ui/ReSearchBtn.tsx
+++ b/src/components/ui/ReSearchBtn.tsx
@@ -3,7 +3,7 @@
 import Refresh from './icons/Refresh';
 import { useIsSidebarOpen } from '@/store/sidebarStateStore';
 import { useMapRef } from '@/store/useMapRefStore';
-import { useMapDataStore } from '@/store/useMapDataStore';
+import { DEFAULT_LOCATION, useMapDataStore } from '@/store/useMapDataStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useGetTypeStore } from '@/store/getTypeStore';
 import { useIsInSeoulStroe } from '@/store/isInSeoulStore';
@@ -28,7 +28,7 @@ const ReSearchBtn = () => {
 
 	const isMoved =
 		center.lat !== searchCenter.lat || center.lng !== searchCenter.lng;
-	return isMoved && isInSeoul ? (
+	return isMoved && isInSeoul && center !== DEFAULT_LOCATION ? (
 		<button
 			onClick={() => handleClickResearch(mapRef.current!)}
 			className={`Elevation-2-Bottom fixed bottom-[50px] left-0 right-0 mx-auto flex w-max justify-between gap-S-4 rounded-[32px] bg-Green-400 px-S-20 py-S-12 text-white Title-Small 

--- a/src/components/ui/ReSearchBtn.tsx
+++ b/src/components/ui/ReSearchBtn.tsx
@@ -6,6 +6,7 @@ import { useMapRef } from '@/store/useMapRefStore';
 import { useMapDataStore } from '@/store/useMapDataStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useGetTypeStore } from '@/store/getTypeStore';
+import { useIsInSeoulStroe } from '@/store/isInSeoulStore';
 
 const ReSearchBtn = () => {
 	const { center, searchCenter, setSearchCenter } = useMapDataStore(
@@ -15,6 +16,7 @@ const ReSearchBtn = () => {
 	const mapRef = useMapRef();
 
 	const { setGetType } = useGetTypeStore();
+	const { isInSeoul } = useIsInSeoulStroe();
 
 	const handleClickResearch = (map: kakao.maps.Map) => {
 		const latlng = map.getCenter();
@@ -26,7 +28,7 @@ const ReSearchBtn = () => {
 
 	const isMoved =
 		center.lat !== searchCenter.lat || center.lng !== searchCenter.lng;
-	return isMoved ? (
+	return isMoved && isInSeoul ? (
 		<button
 			onClick={() => handleClickResearch(mapRef.current!)}
 			className={`Elevation-2-Bottom fixed bottom-[50px] left-0 right-0 mx-auto flex w-max justify-between gap-S-4 rounded-[32px] bg-Green-400 px-S-20 py-S-12 text-white Title-Small 

--- a/src/components/ui/toasts/ToastComplete.tsx
+++ b/src/components/ui/toasts/ToastComplete.tsx
@@ -3,11 +3,7 @@
 import Success from '@/public/icons/success.svg';
 import { useCompleteToastStore } from '@/store/completeToastStore';
 import { useEffect, useRef, useState } from 'react';
-
-const completeMessages = {
-	REGISTER: '방문 기록이 등록되었습니다',
-	COPY: '주소가 복사되었습니다',
-};
+import { COMPLETE_MESSAGES } from '@/utils/toastMessages';
 
 export default function ToastComplete() {
 	const [isVisible, setIsVisible] = useState(true);
@@ -16,7 +12,7 @@ export default function ToastComplete() {
 	const timerRef = useRef<NodeJS.Timeout | null>(null);
 
 	useEffect(() => {
-		const message = completeMessages[completeContent] || '';
+		const message = COMPLETE_MESSAGES[completeContent] || '';
 		setCompleteMessage(message);
 		timerRef.current = setTimeout(() => {
 			setIsVisible(false);

--- a/src/components/ui/toasts/ToastError.tsx
+++ b/src/components/ui/toasts/ToastError.tsx
@@ -4,29 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import Alert from '../icons/Alert';
 import { useIsSidebarOpen } from '@/store/sidebarStateStore';
 import { useErrorToastStore } from '@/store/errorToastStore';
-
-const errorMessages = {
-	FILTER: {
-		title: '한 개 이상의 필터를 선택해주세요',
-		description: '',
-	},
-	SEARCH: {
-		title: '검색 결과가 없습니다',
-		description: '검색어를 다시 확인해주세요',
-	},
-	SEOUL: {
-		title: '더 이상 조회할 수 없습니다',
-		description: '지금은 서울시의 수거함만 조회할 수 있어요',
-	},
-	DATA: {
-		title: '수거함 정보가 없습니다',
-		description: '더 많은 정보를 불러올 수 있도록 준비 중이에요',
-	},
-	REVIEW: {
-		title: '방문 기록을 등록할 수 없습니다',
-		description: '방문 기록은 24시간 이후에 재등록할 수 있어요',
-	},
-};
+import { ERROR_MESSAGES } from '@/utils/toastMessages';
 
 export default function ToastError() {
 	const [isVisible, setIsVisible] = useState(true);
@@ -39,7 +17,7 @@ export default function ToastError() {
 	const timerRef = useRef<NodeJS.Timeout | null>(null);
 
 	useEffect(() => {
-		const message = errorMessages[errorContent] || {
+		const message = ERROR_MESSAGES[errorContent] || {
 			title: '',
 			description: '',
 		};

--- a/src/store/isInSeoulStore.ts
+++ b/src/store/isInSeoulStore.ts
@@ -1,0 +1,15 @@
+import { createStore } from './store';
+
+interface IsInSeoulState {
+	isInSeoul: boolean;
+	setIsInSeoul: (value: boolean | ((prevState: boolean) => boolean)) => void;
+}
+
+export const useIsInSeoulStroe = createStore<IsInSeoulState>((set) => ({
+	isInSeoul: true,
+	setIsInSeoul: (value: boolean | ((prevState: boolean) => boolean)) =>
+		set((state) => {
+			state.isInSeoul =
+				typeof value === 'function' ? value(state.isInSeoul) : value;
+		}),
+}));

--- a/src/store/useMapDataStore.ts
+++ b/src/store/useMapDataStore.ts
@@ -3,7 +3,7 @@ import { createStore } from './store';
 import { LocationType } from '@/types/define';
 
 // NOTE: 위치정보 미허용시 default 값 서울특별시청
-const DEFAULT_LOCATION = {
+export const DEFAULT_LOCATION = {
 	lat: 37.566826004661,
 	lng: 126.978652258309,
 };

--- a/src/utils/methodTypes.ts
+++ b/src/utils/methodTypes.ts
@@ -61,4 +61,4 @@ export const methodTypes = [
 			},
 		],
 	},
-];
+] as const;

--- a/src/utils/toastMessages.ts
+++ b/src/utils/toastMessages.ts
@@ -1,0 +1,27 @@
+export const ERROR_MESSAGES = {
+	FILTER: {
+		title: '한 개 이상의 필터를 선택해주세요',
+		description: '',
+	},
+	SEARCH: {
+		title: '검색 결과가 없습니다',
+		description: '검색어를 다시 확인해주세요',
+	},
+	SEOUL: {
+		title: '더 이상 조회할 수 없습니다',
+		description: '지금은 서울시의 수거함만 조회할 수 있어요',
+	},
+	DATA: {
+		title: '수거함 정보가 없습니다',
+		description: '더 많은 정보를 불러올 수 있도록 준비 중이에요',
+	},
+	REVIEW: {
+		title: '방문 기록을 등록할 수 없습니다',
+		description: '방문 기록은 24시간 이후에 재등록할 수 있어요',
+	},
+};
+
+export const COMPLETE_MESSAGES = {
+	REGISTER: '방문 기록이 등록되었습니다',
+	COPY: '주소가 복사되었습니다',
+};

--- a/src/utils/toastMessages.ts
+++ b/src/utils/toastMessages.ts
@@ -19,9 +19,9 @@ export const ERROR_MESSAGES = {
 		title: '방문 기록을 등록할 수 없습니다',
 		description: '방문 기록은 24시간 이후에 재등록할 수 있어요',
 	},
-};
+} as const;
 
 export const COMPLETE_MESSAGES = {
 	REGISTER: '방문 기록이 등록되었습니다',
 	COPY: '주소가 복사되었습니다',
-};
+} as const;


### PR DESCRIPTION
- 초기 위치인 서울시청에 데이터가 없어서 처음 접속시 토스트 뜨는 것 방지.
- 마커 데이터 필터 로직과 뷰 로직 useMemo로 분리.
- 서울이 아닌 지역에서 이지역 재검색 버튼 안나타나게 처리.